### PR TITLE
[VT2-100] feat: 플로팅 라벨 인풋 컴포넌트 구현

### DIFF
--- a/src/components/FloatingLabelInput/FloatingLabelInput.tsx
+++ b/src/components/FloatingLabelInput/FloatingLabelInput.tsx
@@ -1,18 +1,18 @@
-import React from 'react'
+import { ChangeEvent } from 'react'
 
 interface FloatingLabelInputProps {
   label: string
   id: string
   type?: string
   value: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
   required?: boolean
   disabled?: boolean
   error?: boolean
   className?: string
 }
 
-const FloatingLabelInput: React.FC<FloatingLabelInputProps> = ({
+const FloatingLabelInput = ({
   label,
   id,
   type = 'text',
@@ -22,7 +22,7 @@ const FloatingLabelInput: React.FC<FloatingLabelInputProps> = ({
   disabled = false,
   error = false,
   className = '',
-}) => {
+}: FloatingLabelInputProps) => {
   return (
     <div className={`relative ${className}`}>
       <input

--- a/src/components/FloatingLabelInput/FloatingLabelInput.tsx
+++ b/src/components/FloatingLabelInput/FloatingLabelInput.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+interface FloatingLabelInputProps {
+  label: string
+  id: string
+  type?: string
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  required?: boolean
+  disabled?: boolean
+  error?: boolean
+  className?: string
+}
+
+const FloatingLabelInput: React.FC<FloatingLabelInputProps> = ({
+  label,
+  id,
+  type = 'text',
+  value,
+  onChange,
+  required = false,
+  disabled = false,
+  error = false,
+  className = '',
+}) => {
+  return (
+    <div className={`relative ${className}`}>
+      <input
+        type={type}
+        id={id}
+        value={value}
+        onChange={onChange}
+        required={required}
+        disabled={disabled}
+        placeholder=""
+        className={`peer block w-full rounded-sm border bg-white px-3.5 py-4 text-sm text-gray-900 focus:ring-0 focus:outline-none disabled:cursor-not-allowed ${error ? 'border-red-500 focus:border-red-500' : 'focus:border-pri-500 hover:border-pri-500 border-gray-400'} `}
+      />
+      <label
+        htmlFor={id}
+        className={`font-regular absolute top-2 left-2 z-10 origin-[0] -translate-y-4 scale-75 transform bg-white px-2 text-sm duration-300 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:scale-100 peer-focus:top-2 peer-focus:-translate-y-4 peer-focus:scale-75 peer-focus:px-2 ${error ? 'text-red-500' : 'peer-focus:text-pri-500 text-gray-400'} `}
+      >
+        {label}
+      </label>
+    </div>
+  )
+}
+
+export default FloatingLabelInput

--- a/src/index.css
+++ b/src/index.css
@@ -142,3 +142,17 @@ textarea {
   font-family: inherit;
   transition: 0.2s ease;
 }
+
+/* 자동 완성 배경 색상 제거 */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+textarea:-webkit-autofill,
+textarea:-webkit-autofill:hover,
+textarea:-webkit-autofill:focus,
+select:-webkit-autofill,
+select:-webkit-autofill:hover,
+select:-webkit-autofill:focus {
+  box-shadow: 0 0 0px 1000px white inset;
+  -webkit-text-fill-color: black;
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,7 +1,11 @@
 import { useNavigate } from 'react-router-dom'
+import FloatingLabelInput from '../components/FloatingLabelInput/FloatingLabelInput'
+import { useState } from 'react'
 
 const MainPage = () => {
   const navigate = useNavigate()
+
+  const [email, setEmail] = useState('')
 
   const handleGoToLogin = () => {
     navigate('/login')
@@ -10,6 +14,12 @@ const MainPage = () => {
     <>
       <div>MainPage 25.07.02 11:22</div>
       <button onClick={handleGoToLogin}>로그인 페이지로 이동</button>
+      <FloatingLabelInput
+        id="name"
+        label="이름"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
     </>
   )
 }


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 플로팅 라벨 인풋 컴포넌트 구현

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- label, id, type, value, onChange, required, disabled, error, className 등 props로 유연하게 제어 가능
- input focus 시 label이 플로팅되며, 값 없을 때는 placeholder 위치에 고정
- 에러 시 border, label 색상이 빨간색으로 표시되도록 처리

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- props 분기 처리 없이 플로팅 라벨 인풋 하나로 컴포넌트 구현했습니다. 추후 변경될 수 있는 점 참고 부탁드립니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
<img width="408" height="61" alt="스크린샷 2025-07-17 오전 11 33 26" src="https://github.com/user-attachments/assets/595eba13-c496-4a91-a207-6fdcfe7393ee" />
<img width="408" height="64" alt="스크린샷 2025-07-17 오전 11 33 41" src="https://github.com/user-attachments/assets/54b3465c-b67b-4510-afcb-25b957d802f3" />



## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
