### PR TITLE
[VT2-137] feat: 카드 컴포넌트 구현

### DIFF
--- a/src/assets/icons/arrowRightIcon.svg
+++ b/src/assets/icons/arrowRightIcon.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="19" viewBox="0 0 10 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.5 17.502L7.93043 10.9161C8.68986 10.1383 8.68986 8.86559 7.93043 8.08781L1.5 1.50195" stroke="currentColor" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/noticeIcon.svg
+++ b/src/assets/icons/noticeIcon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 8V13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.9941 16H12.0031" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/warningIcon.svg
+++ b/src/assets/icons/warningIcon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 9V14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.9994 21.4112H5.93944C2.46944 21.4112 1.01944 18.9312 2.69944 15.9012L5.81944 10.2812L8.75944 5.00125C10.5394 1.79125 13.4594 1.79125 15.2394 5.00125L18.1794 10.2913L21.2994 15.9113C22.9794 18.9413 21.5194 21.4212 18.0594 21.4212H11.9994V21.4112Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.9941 17H12.0031" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { useDeviceType } from '../../hooks/useDeviceType'
+import WarningIcon from '../../assets/icons/warningIcon.svg?react'
+import NoticeIcon from '../../assets/icons/noticeIcon.svg?react'
+import ArrowRightIcon from '../../assets/icons/arrowRightIcon.svg?react'
+
+interface CardProps {
+  type?: 'default' | 'label' | 'warning' | 'notice'
+  className?: string
+  labelTitle?: string
+  iconTitle?: string
+  iconDescription?: string
+  children?: React.ReactNode
+}
+const typeStyles = {
+  warning: {
+    cardBg: 'bg-error-light',
+    icon: WarningIcon,
+    iconWrapper: 'bg-error text-error-light',
+    title: 'text-error',
+  },
+  notice: {
+    cardBg: 'bg-gray-10',
+    icon: NoticeIcon,
+    iconWrapper: 'bg-pri-500 text-pri-100',
+    title: 'text-pri-700',
+  },
+}
+
+const Card = ({
+  type = 'default',
+  className = '',
+  labelTitle,
+  iconTitle,
+  iconDescription,
+  children,
+}: CardProps) => {
+  const deviceType = useDeviceType()
+  const paddingClass = deviceType === 'mobile' ? 'p-4 gap-4' : 'p-5 gap-5'
+  const labelTextClass = deviceType === 'mobile' ? 'text-fs18' : 'text-fs20'
+  const isIconType = type === 'warning' || type === 'notice'
+  const iconCardStyle = isIconType ? typeStyles[type] : undefined
+  const Icon = iconCardStyle?.icon
+  return (
+    <div
+      className={`shadow-card flex w-full flex-col rounded-md ${paddingClass} ${
+        isIconType ? iconCardStyle?.cardBg : 'bg-gray-10'
+      } ${className}`}
+    >
+      {type === 'label' && labelTitle && (
+        <div className="flex flex-col gap-2">
+          <div className={`w-full font-medium text-gray-900 ${labelTextClass}`}>{labelTitle}</div>
+          <hr className="border-t border-gray-100" />
+        </div>
+      )}
+      {isIconType && iconTitle && iconDescription ? (
+        <div
+          className={`flex w-full items-center gap-3 ${type === 'notice' ? 'justify-between' : ''}`}
+        >
+          <div
+            className={`text-fs24 flex h-12 w-12 items-center justify-center rounded-full ${iconCardStyle?.iconWrapper}`}
+          >
+            {Icon && <Icon />}
+          </div>
+          <div className="flex w-full flex-col justify-center gap-1">
+            <p className={`text-fs20 font-medium ${iconCardStyle?.title}`}>{iconTitle}</p>
+            <p className="text-fs14 text-gray-700">{iconDescription}</p>
+          </div>
+          {type === 'notice' && (
+            <div className="flex items-center">
+              <ArrowRightIcon />
+            </div>
+          )}
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  )
+}
+
+export default Card

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -39,19 +39,31 @@ const Card = ({
   const isIconType = type === 'warning' || type === 'notice'
   const iconCardStyle = isIconType ? typeStyles[type] : undefined
   const Icon = iconCardStyle?.icon
+
+  const responsiveStyles =
+    deviceType === 'mobile'
+      ? {
+          wrapper: 'p-4 gap-4',
+          iconTitle: 'text-fs16',
+          iconDescription: 'text-fs12',
+          labelTitle: 'text-fs18',
+        }
+      : {
+          wrapper: 'p-5 gap-5',
+          iconTitle: 'text-fs20',
+          iconDescription: 'text-fs14',
+          labelTitle: 'text-fs20',
+        }
+
   return (
     <div
-      className={`shadow-card flex w-full flex-col rounded-md ${
-        deviceType === 'mobile' ? 'gap-4 p-4' : 'gap-5 p-5'
-      } ${isIconType ? iconCardStyle?.cardBg : 'bg-gray-10'} ${className}`}
+      className={`shadow-card flex w-full flex-col rounded-md ${responsiveStyles.wrapper} ${
+        isIconType ? iconCardStyle?.cardBg : 'bg-gray-10'
+      } ${className}`}
     >
       {type === 'label' && labelTitle && (
         <div className="flex flex-col gap-2">
-          <div
-            className={`w-full font-medium text-gray-900 ${
-              deviceType === 'mobile' ? 'text-fs18' : 'text-fs20'
-            }`}
-          >
+          <div className={`w-full font-medium text-gray-900 ${responsiveStyles.labelTitle}`}>
             {labelTitle}
           </div>
           <hr className="border-t border-gray-100" />
@@ -67,14 +79,10 @@ const Card = ({
             {Icon && <Icon />}
           </div>
           <div className="flex w-full flex-col justify-center gap-1">
-            <p
-              className={`${deviceType === 'mobile' ? 'text-fs16' : 'text-fs20'} font-medium ${iconCardStyle?.title}`}
-            >
+            <p className={`${responsiveStyles.iconTitle} font-medium ${iconCardStyle?.title}`}>
               {iconTitle}
             </p>
-            <p className={`${deviceType === 'mobile' ? 'text-fs12' : 'text-fs14'} text-gray-700`}>
-              {iconDescription}
-            </p>
+            <p className={`${responsiveStyles.iconDescription} text-gray-700`}>{iconDescription}</p>
           </div>
           {type === 'notice' && (
             <div className="flex items-center">

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -36,20 +36,24 @@ const Card = ({
   children,
 }: CardProps) => {
   const deviceType = useDeviceType()
-  const paddingClass = deviceType === 'mobile' ? 'p-4 gap-4' : 'p-5 gap-5'
-  const labelTextClass = deviceType === 'mobile' ? 'text-fs18' : 'text-fs20'
   const isIconType = type === 'warning' || type === 'notice'
   const iconCardStyle = isIconType ? typeStyles[type] : undefined
   const Icon = iconCardStyle?.icon
   return (
     <div
-      className={`shadow-card flex w-full flex-col rounded-md ${paddingClass} ${
-        isIconType ? iconCardStyle?.cardBg : 'bg-gray-10'
-      } ${className}`}
+      className={`shadow-card flex w-full flex-col rounded-md ${
+        deviceType === 'mobile' ? 'gap-4 p-4' : 'gap-5 p-5'
+      } ${isIconType ? iconCardStyle?.cardBg : 'bg-gray-10'} ${className}`}
     >
       {type === 'label' && labelTitle && (
         <div className="flex flex-col gap-2">
-          <div className={`w-full font-medium text-gray-900 ${labelTextClass}`}>{labelTitle}</div>
+          <div
+            className={`w-full font-medium text-gray-900 ${
+              deviceType === 'mobile' ? 'text-fs18' : 'text-fs20'
+            }`}
+          >
+            {labelTitle}
+          </div>
           <hr className="border-t border-gray-100" />
         </div>
       )}
@@ -58,13 +62,19 @@ const Card = ({
           className={`flex w-full items-center gap-3 ${type === 'notice' ? 'justify-between' : ''}`}
         >
           <div
-            className={`text-fs24 flex h-12 w-12 items-center justify-center rounded-full ${iconCardStyle?.iconWrapper}`}
+            className={`text-fs24 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full ${iconCardStyle?.iconWrapper}`}
           >
             {Icon && <Icon />}
           </div>
           <div className="flex w-full flex-col justify-center gap-1">
-            <p className={`text-fs20 font-medium ${iconCardStyle?.title}`}>{iconTitle}</p>
-            <p className="text-fs14 text-gray-700">{iconDescription}</p>
+            <p
+              className={`${deviceType === 'mobile' ? 'text-fs16' : 'text-fs20'} font-medium ${iconCardStyle?.title}`}
+            >
+              {iconTitle}
+            </p>
+            <p className={`${deviceType === 'mobile' ? 'text-fs12' : 'text-fs14'} text-gray-700`}>
+              {iconDescription}
+            </p>
           </div>
           {type === 'notice' && (
             <div className="flex items-center">

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,7 @@
 
   /* Mild 색상 */
   --color-error: #e94e4e;
+  --color-error-light: #ffefef;
   --color-success: #48bb78;
   --color-background: #f7f8f9;
   --color-skt: #3617ce;
@@ -132,6 +133,7 @@ body {
   letter-spacing: -0.02em;
   font-weight: var(--font-weight-regular);
   background-color: var(--color-background);
+  line-height: 1.2;
 }
 
 a {

--- a/src/pages/PayChargeResultPage.tsx
+++ b/src/pages/PayChargeResultPage.tsx
@@ -1,0 +1,35 @@
+import Card from '../components/Card/Card'
+
+const PayChargeResultPage = () => {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* default card */}
+      <Card>
+        <p>기본 카드</p>
+      </Card>
+      {/* label card */}
+      <Card type="label" labelTitle="환전페이">
+        <p>카드카드</p>
+        <p>카드카드</p>
+        <div className="flex justify-between">
+          <p>내부 요소 정상 작동 확인용</p>
+          <p>잘 됨</p>
+        </div>
+      </Card>
+      {/* notice card */}
+      <Card
+        type="notice"
+        iconTitle="페이 변동 내역 보러가기"
+        iconDescription="충전 및 환전, 거래로 변동된 페이 내역을 한 눈에 확인해보세요!"
+      />
+      {/* warning card */}
+      <Card
+        type="warning"
+        iconTitle="데이터 전환 시, 보유 데이터로 재전환이 불가합니다."
+        iconDescription="신중하게 결정해주세요!"
+      />
+    </div>
+  )
+}
+
+export default PayChargeResultPage

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,6 +4,7 @@ import LoginPage from '../pages/LoginPage'
 import AuthLayout from '../layout/AuthLayout'
 import DefaultLayout from '../layout/DefaultLayout'
 import MyPage from '../pages/MyPage'
+import PayChargeResultPage from '../pages/PayChargeResultPage'
 
 export const router = createBrowserRouter([
   {
@@ -25,6 +26,10 @@ export const router = createBrowserRouter([
       {
         path: '/mypage/:tabId',
         element: <MyPage />,
+      },
+      {
+        path: '/charge-result',
+        element: <PayChargeResultPage />,
       },
     ],
   },

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg?react' {
+  import * as React from 'react'
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement> & { title?: string }>
+  export default ReactComponent
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,15 @@ const dirname =
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
-  plugins: [tailwindcss(), svgr(), react()],
+  plugins: [
+    tailwindcss(),
+    svgr({
+      svgrOptions: {
+        icon: true,
+      },
+    }),
+    react(),
+  ],
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     alias: {


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 아이콘 파일 추가 및 svgr 플러그인 업데이트
2. error-light 색상 추가 및 line-height 1.5 -> 1.2로 변경
3. 기본, 라벨, 아이콘 카드 구현
4. 반응형 구현

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 총 4가지 type : default, label, notice, warning
- 모바일 반응형 : font-size, padding, gap 감소
- svgr에서 currentColor 활용하기 위해 svgr 플러그인 업데이트
- error 카드 배경색이 따로 없길래 error-light 추가
- line-height 1.5 -> 1.2로 변경 (body에 적용)

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- svgr 설치가 이미 되어 있길래 설치는 따로 하지 않았습니다. 그래도 혹시 모르니.. npm install 한 번 부탁드림다
- Labels 뭐로 선택해야 하는지 또 까먹었습니다 한 번만 더 알려주세여.. ><
## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

![CardCompo](https://github.com/user-attachments/assets/b578f6c7-a2de-4924-b7a6-89029035e1b9)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
