### PR TITLE
[VT2-94] feat: WebMobileLayout 구현

### DIFF
--- a/src/assets/icons/back.svg
+++ b/src/assets/icons/back.svg
@@ -1,3 +1,3 @@
 <svg width="10" height="18" viewBox="0 0 10 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8.99995 1L1.7071 8.2929C1.37377 8.62623 1.2071 8.79289 1.2071 9C1.2071 9.20711 1.37377 9.37377 1.7071 9.7071L8.99995 17" stroke="#141B34" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.99995 1L1.7071 8.2929C1.37377 8.62623 1.2071 8.79289 1.2071 9C1.2071 9.20711 1.37377 9.37377 1.7071 9.7071L8.99995 17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icons/back.svg
+++ b/src/assets/icons/back.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="18" viewBox="0 0 10 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.99995 1L1.7071 8.2929C1.37377 8.62623 1.2071 8.79289 1.2071 9C1.2071 9.20711 1.37377 9.37377 1.7071 9.7071L8.99995 17" stroke="#141B34" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -6,6 +6,6 @@ interface ContainerProps {
 }
 
 const Container = ({ children, className = '' }: ContainerProps) => {
-  return <div className={`mx-auto h-full w-full max-w-[1280px] ${className}`}>{children}</div>
+  return <div className={`mx-auto h-full w-full ${className}`}>{children}</div>
 }
 export default Container

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -19,7 +19,7 @@ const Header = () => {
 
   return (
     <header className="bg-gray-10 fixed z-50 flex h-16 w-full items-center p-4 shadow-xs sm:h-21.5">
-      <Container className="flex items-center justify-between gap-4">
+      <Container className="flex max-w-[1280px] items-center justify-between gap-4">
         <div
           onClick={() => {
             setShowMobileSearch(false)

--- a/src/layout/DefaultLayout.tsx
+++ b/src/layout/DefaultLayout.tsx
@@ -4,10 +4,10 @@ import Header from '../components/Header/Header'
 
 const DefaultLayout = () => {
   return (
-    <div className="bg-background flex min-h-[100vh] flex-col items-center">
+    <div className="bg-background flex min-h-screen flex-col items-center">
       <Header />
-      <main className="mt-16 w-full flex-1 px-4 pt-6 sm:mt-21.5 sm:pt-10">
-        <Container>
+      <main className="mt-16 w-full flex-1 pt-6 sm:mt-21.5 sm:px-4 sm:pt-10">
+        <Container className="max-w-[1280px]">
           <Outlet />
         </Container>
       </main>

--- a/src/layout/WebMobileLayout.tsx
+++ b/src/layout/WebMobileLayout.tsx
@@ -1,0 +1,27 @@
+import BackIcon from '@/assets/icons/back.svg?react'
+import { Outlet, useMatches } from 'react-router-dom'
+import Container from '../components/Container/Container'
+
+const WebMobileLayout = () => {
+  // 현재 경로에 매칭된 라우트 배열에서 타이틀을 가져와 헤더에 표시
+  const matches = useMatches() as { handle?: { title?: string } }[]
+  const title = matches.reverse().find(match => match.handle?.title)?.handle?.title ?? ''
+
+  return (
+    <div className="bg-background flex h-full min-h-screen flex-col">
+      <header className="bg-gray-10 fixed z-50 flex h-16 w-full items-center p-4 shadow-xs sm:h-21.5">
+        <Container className="relative flex max-w-[640px] items-center justify-center">
+          <BackIcon className="absolute top-1/2 left-0 -translate-y-1/2" />
+          <h1 className="text-fs20 font-medium">{title}</h1>
+        </Container>
+      </header>
+      <main className="mt-16 w-full flex-1 pt-6 sm:mt-21.5 sm:pt-10">
+        <Container className="max-w-[640px]">
+          <Outlet />
+        </Container>
+      </main>
+    </div>
+  )
+}
+
+export default WebMobileLayout

--- a/src/layout/WebMobileLayout.tsx
+++ b/src/layout/WebMobileLayout.tsx
@@ -1,8 +1,10 @@
 import BackIcon from '@/assets/icons/back.svg?react'
-import { Outlet, useMatches } from 'react-router-dom'
+import { Outlet, useMatches, useNavigate } from 'react-router-dom'
 import Container from '../components/Container/Container'
 
 const WebMobileLayout = () => {
+  const navigate = useNavigate()
+
   // 현재 경로에 매칭된 라우트 배열에서 타이틀을 가져와 헤더에 표시
   const matches = useMatches() as { handle?: { title?: string } }[]
   const title = matches.reverse().find(match => match.handle?.title)?.handle?.title ?? ''
@@ -11,7 +13,10 @@ const WebMobileLayout = () => {
     <div className="bg-background flex h-full min-h-screen flex-col">
       <header className="bg-gray-10 fixed z-50 flex h-16 w-full items-center p-4 shadow-xs sm:h-21.5">
         <Container className="relative flex max-w-[640px] items-center justify-center">
-          <BackIcon className="absolute top-1/2 left-0 -translate-y-1/2" />
+          <BackIcon
+            className="absolute top-1/2 left-0 -translate-y-1/2 cursor-pointer text-black"
+            onClick={() => navigate(-1)}
+          />
           <h1 className="text-fs20 font-medium">{title}</h1>
         </Container>
       </header>

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -1,0 +1,5 @@
+const WritePage = () => {
+  return <div>WritePage</div>
+}
+
+export default WritePage

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -5,6 +5,8 @@ import AuthLayout from '../layout/AuthLayout'
 import DefaultLayout from '../layout/DefaultLayout'
 import MyPage from '../pages/MyPage'
 import PayChargeResultPage from '../pages/PayChargeResultPage'
+import WebMobileLayout from '../layout/WebMobileLayout'
+import WritePage from '../pages/WritePage'
 
 export const router = createBrowserRouter([
   {
@@ -30,6 +32,16 @@ export const router = createBrowserRouter([
       {
         path: '/charge-result',
         element: <PayChargeResultPage />,
+      },
+    ],
+  },
+  {
+    element: <WebMobileLayout />,
+    children: [
+      {
+        path: '/write',
+        element: <WritePage />,
+        handle: { title: '내 데이터 판매' },
       },
     ],
   },


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1.  WebMobileLayout 마크업
2. 헤더 타이틀 동적 적용

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- useMatches 활용하여 타이틀 동적으로 적용
- 뒤로가기 아이콘 및 동작 적용

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 레이아웃 적용 확인을 위해 임시로 WritePage 생성했습니다. 추후 삭제나 변경하여 사용해주시길 바랍니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

### 데스크탑 및 태블릿
<img width="955" height="831" alt="스크린샷 2025-07-21 오후 12 04 10" src="https://github.com/user-attachments/assets/b9e0b496-b6c6-4781-b006-4c0826cbff6e" />

### 모바일
<img width="437" height="832" alt="스크린샷 2025-07-21 오후 12 04 20" src="https://github.com/user-attachments/assets/926d31f3-6515-4371-86a8-d14c51d0e8d4" />


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
