### PR TITLE
[VT2-100] fix: Input 컴포넌트 error prop을 error와 errorMsg 따로 분리

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -11,7 +11,8 @@ interface InputProps {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void
   required?: boolean
   disabled?: boolean
-  error?: string
+  error?: boolean
+  errorMsg?: string
   shape?: 'square' | 'floating' | 'underline'
   prefix?: ReactNode
   suffix?: ReactNode
@@ -27,7 +28,8 @@ const Input = ({
   onChange,
   required = false,
   disabled = false,
-  error = '',
+  error = false,
+  errorMsg = '',
   shape = 'square',
   prefix,
   suffix,
@@ -143,7 +145,7 @@ const Input = ({
         )}
       </div>
 
-      {error && <span className="text-error text-fs12 p-1 text-left">{error}</span>}
+      {error && errorMsg && <span className="text-error text-fs12 p-1 text-left">{errorMsg}</span>}
     </div>
   )
 }

--- a/src/pages/LoginPage/components/LoginForm.tsx
+++ b/src/pages/LoginPage/components/LoginForm.tsx
@@ -68,7 +68,8 @@ const LoginForm = () => {
               field.onChange(e)
               if (errors.email) clearErrors('email')
             }}
-            error={errors.email?.message}
+            error={!!errors.email}
+            errorMsg={errors.email?.message}
             shape={deviceType === 'mobile' ? 'square' : 'floating'}
           />
         )}
@@ -87,7 +88,8 @@ const LoginForm = () => {
               field.onChange(e)
               if (errors.password) clearErrors('password')
             }}
-            error={errors.password?.message}
+            error={!!errors.password}
+            errorMsg={errors.password?.message}
             shape={deviceType === 'mobile' ? 'square' : 'floating'}
           />
         )}

--- a/src/pages/SignUpPage/components/AddtionalInfoForm.tsx
+++ b/src/pages/SignUpPage/components/AddtionalInfoForm.tsx
@@ -97,7 +97,8 @@ const AddtionalInfoForm = () => {
                   const formatted = formatPhoneNumber(e.target.value)
                   field.onChange(formatted)
                 }}
-                error={errors.phoneNumber?.message}
+                error={!!errors.phoneNumber}
+                errorMsg={errors.phoneNumber?.message}
                 shape={deviceType === 'mobile' ? 'square' : 'floating'}
               />
             )}

--- a/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -98,7 +98,8 @@ const SignUpForm = () => {
               onChange={e => {
                 field.onChange(e)
               }}
-              error={errors.email?.message}
+              error={!!errors.email}
+              errorMsg={errors.email?.message}
               shape={deviceType === 'mobile' ? 'square' : 'floating'}
               suffix={
                 <Button
@@ -127,7 +128,8 @@ const SignUpForm = () => {
               onChange={e => {
                 field.onChange(e)
               }}
-              error={errors.password?.message}
+              error={!!errors.password}
+              errorMsg={errors.password?.message}
               shape={deviceType === 'mobile' ? 'square' : 'floating'}
             />
           )}
@@ -145,7 +147,8 @@ const SignUpForm = () => {
               onChange={e => {
                 field.onChange(e)
               }}
-              error={errors.passwordConfirm?.message}
+              error={!!errors.passwordConfirm}
+              errorMsg={errors.passwordConfirm?.message}
               shape={deviceType === 'mobile' ? 'square' : 'floating'}
             />
           )}
@@ -178,7 +181,8 @@ const SignUpForm = () => {
                   const formatted = formatPhoneNumber(e.target.value)
                   field.onChange(formatted)
                 }}
-                error={errors.phoneNumber?.message}
+                error={!!errors.phoneNumber}
+                errorMsg={errors.phoneNumber?.message}
                 shape={deviceType === 'mobile' ? 'square' : 'floating'}
               />
             )}


### PR DESCRIPTION
…도록 분리

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. Input 컴포넌트 error prop을 error와 errorMsg 따로 분리

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- error prop은 에러 여부를 받음
- errorMsg prop은 에러 메시지를 받음

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 확인 부탁드립니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
