### PR TITLE
[VT2-91] feat: 관리자 대시보드 마크업

### DIFF
--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -1,0 +1,63 @@
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import Toggle from './Toggle'
+
+const meta: Meta<typeof Toggle> = {
+  title: 'Components/Toggle',
+  component: Toggle,
+  globals: {
+    backgrounds: { value: 'background' },
+  },
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Toggle 컴포넌트는 ON/OFF 상태를 전환할 수 있는 스위치 형태의 컴포넌트입니다.',
+      },
+    },
+  },
+  argTypes: {
+    initialState: {
+      control: 'boolean',
+      description: '토글의 초기 상태',
+    },
+    onToggle: {
+      action: 'toggled',
+      description: '토글 상태 변경 시 호출되는 콜백',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Toggle>
+
+export const Default: Story = {
+  args: {
+    initialState: false,
+  },
+  render: args => {
+    const ToggleWrapper = () => {
+      const [isOn, setIsOn] = useState(args.initialState!)
+      const handleToggle = () => setIsOn(prev => !prev)
+
+      return <Toggle {...args} initialState={isOn} onToggle={handleToggle} />
+    }
+    return <ToggleWrapper />
+  },
+}
+
+export const InitiallyOn: Story = {
+  args: {
+    initialState: true,
+  },
+  render: args => {
+    const ToggleWrapper = () => {
+      const [isOn, setIsOn] = useState(args.initialState!)
+      const handleToggle = () => setIsOn(prev => !prev)
+
+      return <Toggle {...args} initialState={isOn} onToggle={handleToggle} />
+    }
+    return <ToggleWrapper />
+  },
+}

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface ToggleProps {
+  initialState?: boolean
+  onToggle?: (state: boolean) => void
+}
+
+const Toggle = ({ initialState = false, onToggle }: ToggleProps) => {
+  const isFirstRender = useRef(true)
+  const [isOn, setIsOn] = useState(initialState)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    onToggle?.(isOn)
+  }, [isOn, onToggle])
+
+  return (
+    <div className="inline-block">
+      <input
+        type="checkbox"
+        id="toggle"
+        checked={isOn}
+        onChange={() => {
+          setIsOn(prev => !prev)
+        }}
+        className="sr-only"
+      />
+      <label
+        htmlFor="toggle"
+        className={`relative inline-block h-6 w-12 cursor-pointer rounded-full transition-colors ${
+          isOn ? 'bg-pri-400' : 'bg-gray-200'
+        }`}
+      >
+        <span
+          className={`bg-gray-10 absolute top-0.5 left-0.5 h-5 w-5 transform rounded-full shadow transition-transform duration-300 ease-in-out ${
+            isOn ? 'translate-x-6' : 'translate-x-0'
+          }`}
+        ></span>
+      </label>
+    </div>
+  )
+}
+
+export default Toggle

--- a/src/components/Toggle/ToggleText.stories.tsx
+++ b/src/components/Toggle/ToggleText.stories.tsx
@@ -1,0 +1,69 @@
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import ToggleText from './ToggleText'
+
+const meta: Meta<typeof ToggleText> = {
+  title: 'Components/ToggleText',
+  component: ToggleText,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'ToggleText는 두 가지 텍스트 중 하나를 선택해 전환할 수 있는 토글 버튼 컴포넌트입니다.',
+      },
+    },
+  },
+  argTypes: {
+    leftText: { control: 'text', description: '왼쪽에 표시될 텍스트' },
+    rightText: { control: 'text', description: '오른쪽에 표시될 텍스트' },
+    initialSelectedText: { control: 'text', description: '초기 선택된 텍스트' },
+    onToggle: { action: 'toggled', description: '선택된 텍스트가 변경될 때 호출되는 콜백' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ToggleText>
+
+type ToggleTextWrapperProps = {
+  leftText: string
+  rightText: string
+  initialSelectedText?: string
+  onToggle?: (selectedText: string) => void
+}
+
+const ToggleTextWrapper = ({
+  leftText,
+  rightText,
+  initialSelectedText,
+  onToggle,
+}: ToggleTextWrapperProps) => {
+  const [selected, setSelected] = useState(initialSelectedText ?? leftText)
+
+  const handleToggle = (text: string) => {
+    setSelected(text)
+    onToggle?.(text)
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <ToggleText
+        leftText={leftText}
+        rightText={rightText}
+        initialSelectedText={selected}
+        onToggle={handleToggle}
+      />
+      <p>현재 선택된 값: {selected}</p>
+    </div>
+  )
+}
+
+export const Default: Story = {
+  args: {
+    leftText: '일반 판매',
+    rightText: '입찰 판매',
+    initialSelectedText: '일반 판매',
+  },
+  render: args => <ToggleTextWrapper {...args} />,
+}

--- a/src/components/Toggle/ToggleText.tsx
+++ b/src/components/Toggle/ToggleText.tsx
@@ -1,0 +1,56 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface ToggleTextProps {
+  leftText: string
+  rightText: string
+  initialSelectedText?: string
+  onToggle?: (selectedText: string) => void
+}
+
+const ToggleText = ({ leftText, rightText, initialSelectedText, onToggle }: ToggleTextProps) => {
+  const isFirstRender = useRef(true)
+  const [selectedText, setSelectedText] = useState(initialSelectedText ?? leftText)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    onToggle?.(selectedText)
+  }, [selectedText, onToggle])
+
+  const isSelected = (text: string) => selectedText === text
+
+  return (
+    <div className="relative h-8 w-50 overflow-hidden rounded-xs bg-gray-100 p-1 select-none">
+      <div
+        className={`bg-gray-10 absolute top-1 left-1 h-6 w-[calc(50%-0.25rem)] rounded-xs shadow-md transition-transform duration-300 ease-in-out ${
+          isSelected(leftText) ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      />
+
+      <div className="flex h-full font-medium">
+        <button
+          type="button"
+          className={`z-10 flex flex-1 items-center justify-center ${
+            isSelected(leftText) ? 'text-black' : 'text-gray-500'
+          }`}
+          onClick={() => setSelectedText(leftText)}
+        >
+          {leftText}
+        </button>
+        <button
+          type="button"
+          className={`z-10 flex flex-1 items-center justify-center ${
+            isSelected(rightText) ? 'text-black' : 'text-gray-500'
+          }`}
+          onClick={() => setSelectedText(rightText)}
+        >
+          {rightText}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ToggleText

--- a/src/layout/AdminLayout.tsx
+++ b/src/layout/AdminLayout.tsx
@@ -4,7 +4,7 @@ import Container from '../components/Container/Container'
 
 const AdminLayout = () => {
   return (
-    <Container className="bg-background flex min-h-screen max-w-[1280px] gap-11">
+    <Container className="bg-background flex min-h-screen max-w-[1280px] gap-11 pr-11 xl:p-0">
       <Sidebar />
       <div className="flex-1 py-13">
         <Outlet />

--- a/src/pages/AdminPage/Dashboard.tsx
+++ b/src/pages/AdminPage/Dashboard.tsx
@@ -1,5 +1,15 @@
+import PriceGraph from './components/PriceGraph'
+import SystemManagement from './components/SystemManagement'
+import VolumeGraph from './components/VolumeGraph'
+
 const Dashboard = () => {
-  return <div>Dashboard</div>
+  return (
+    <div className="space-y-10">
+      <SystemManagement />
+      <PriceGraph />
+      <VolumeGraph />
+    </div>
+  )
 }
 
 export default Dashboard

--- a/src/pages/AdminPage/components/PriceGraph.tsx
+++ b/src/pages/AdminPage/components/PriceGraph.tsx
@@ -1,0 +1,16 @@
+import Card from '../../../components/Card/Card'
+import Graph from '../../../components/Graph/Graph'
+import { lineData } from '../../../mocks/graphData'
+
+const PriceGraph = () => {
+  return (
+    <section className="flex flex-col gap-5">
+      <h2 className="text-fs24">시세 그래프</h2>
+      <Card className="px-0">
+        <Graph type="line" data={lineData} yKeys={['u+', 'kt', 'skt']} height={328} />
+      </Card>
+    </section>
+  )
+}
+
+export default PriceGraph

--- a/src/pages/AdminPage/components/Sidebar.tsx
+++ b/src/pages/AdminPage/components/Sidebar.tsx
@@ -67,7 +67,7 @@ const Sidebar = () => {
 
               <div className="flex items-center gap-4">
                 <Icon className="h-6 w-6" />
-                <span className="ml-1">{item.label}</span>
+                <span className="text-fs20">{item.label}</span>
               </div>
             </Link>
           )

--- a/src/pages/AdminPage/components/SystemManagement.tsx
+++ b/src/pages/AdminPage/components/SystemManagement.tsx
@@ -1,0 +1,66 @@
+import Card from '../../../components/Card/Card'
+import UserIcon from '@/assets/icons/user.svg?react'
+import ReportIcon from '@/assets/icons/report.svg?react'
+
+interface ManagementCardProps {
+  title: string
+  stats: { label: string; value: number }[]
+  icon: React.ReactNode
+  iconBgColor: string
+}
+
+const ManagementCard = ({ title, stats, icon, iconBgColor }: ManagementCardProps) => {
+  return (
+    <Card className="flex-1">
+      <div className="flex items-center justify-between gap-5">
+        <div className="space-y-5">
+          <h3 className="font-bold">{title}</h3>
+          <div className="flex gap-5">
+            {stats.map((stat, idx) => (
+              <div className="space-y-3" key={idx}>
+                <div>{stat.label}</div>
+                <div className="text-fs32">{stat.value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div
+          className={`flex items-center justify-center rounded-full p-9`}
+          style={{ backgroundColor: iconBgColor }}
+        >
+          {icon}
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+const SystemManagement = () => {
+  return (
+    <section className="flex flex-col gap-5">
+      <h2 className="text-fs24">시스템 관리</h2>
+      <div className="flex gap-11">
+        <ManagementCard
+          title="회원 관리"
+          stats={[
+            { label: '오늘 가입한 사용자', value: 17 },
+            { label: '전체 사용자', value: 200 },
+          ]}
+          icon={<UserIcon className="text-pri-400 h-12 w-12" />}
+          iconBgColor="#DCFAF8"
+        />
+        <ManagementCard
+          title="신고 관리"
+          stats={[
+            { label: '오늘 신고 건수', value: 17 },
+            { label: '전체 신고 건수', value: 200 },
+          ]}
+          icon={<ReportIcon className="text-error h-12 w-12" />}
+          iconBgColor="#FFE0E1"
+        />
+      </div>
+    </section>
+  )
+}
+
+export default SystemManagement

--- a/src/pages/AdminPage/components/VolumeGraph.tsx
+++ b/src/pages/AdminPage/components/VolumeGraph.tsx
@@ -1,0 +1,25 @@
+import Card from '../../../components/Card/Card'
+import Graph from '../../../components/Graph/Graph'
+import ToggleText from '../../../components/Toggle/ToggleText'
+import { barData } from '../../../mocks/graphData'
+
+const VolumeGraph = () => {
+  return (
+    <section className="flex flex-col gap-5">
+      <div className="flex justify-between">
+        <h2 className="text-fs24">거래량 그래프</h2>
+        <ToggleText
+          leftText="일반 판매"
+          rightText="입찰 판매"
+          onToggle={state => console.log('텍스트 토글 상태:', state)}
+        />
+      </div>
+
+      <Card className="px-0">
+        <Graph type="bar" data={barData} yKeys={['거래량']} height={328} />
+      </Card>
+    </section>
+  )
+}
+
+export default VolumeGraph


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 관리자 페이지 대시보드 UI 마크업
2. 시스템 관리/시세 그래프/거래량 그래프 UI 컴포넌트 분리
3. 토클/토글 텍스트 컴포넌트 구현 및 스토리북 작성

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 관리자 페이지 대시보드 UI 마크업
- 시스템 관리/시세 그래프/거래량 그래프 UI 컴포넌트 분리
- 토클/토글 텍스트 컴포넌트 구현 및 스토리북 작성

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 토글 관련 컴포넌트 스토리북에서 확인 가능합니다.
- API 연동은 추후 예정입니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

<img width="672" height="378" alt="스크린샷 2025-07-24 오전 11 21 40" src="https://github.com/user-attachments/assets/d1cb0271-81f4-474d-90af-ca3e452ce665" />

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
