### PR TITLE
[VT2-426] fix: 클라이언트 인스턴스에 statusCode 10001 토큰 만료 감지 및 자동 토큰 갱신 인터셉터 등록 로직 수정

### DIFF
--- a/src/apis/interceptors.ts
+++ b/src/apis/interceptors.ts
@@ -25,51 +25,81 @@ export const attachRequestInterceptor = (client: AxiosInstance) => {
  * - statusCode 10001 상태와 errorCode 'TOKEN_EXPIRED'를 반환할 때만 accessToken 갱신 시도
  * - refreshToken으로 갱신 성공 시 원래 요청을 재시도하여 반환
  * - refreshToken도 만료되거나 갱신 실패 시 로그인 페이지로 이동하여 재로그인 유도
- * - 무한 루프 방지를 위해 `_retry` 플래그를 사용
+ * - 무한 루프 방지를 위해 '_retry' 플래그를 사용
+ *
+ * - accessToken이 만료된 상태에서 여러 API 동시 요청 대비: 토큰 갱신 요청은 1번만 발생
+ * - 이후 요청은 해당 Promise를 공유해 결과 대기
+ * - race condition 방지
  *
  * @param client axios 인스턴스
  */
 
+let isRefreshing = false
+let refreshPromise: Promise<string> | null = null
+
 export const attachResponseInterceptor = (client: AxiosInstance) => {
   client.interceptors.response.use(
     async response => {
-      const data = response.data.data
+      // 서버 응답 데이터에서 실제 데이터 부분 추출
+      const data = response.data?.data
 
-      if (data.statusCode === 10001 && data.statusCodeName === 'TOKEN_EXPIRED') {
-        const originalRequest = response.config as AxiosRequestConfig & {
-          _retry?: boolean
-        }
+      // 토큰 만료 에러 감지: 상태 코드 10001, 상태 이름 TOKEN_EXPIRED 인 경우
+      if (data?.statusCode === 10001 && data.statusCodeName === 'TOKEN_EXPIRED') {
+        // 원래 요청 객체를 가져옴, _retry 플래그 추가 가능하도록 확장 타입 지정
+        const originalRequest = response.config as AxiosRequestConfig & { _retry?: boolean }
 
+        // 이미 재시도 했으면 무한 루프 방지 위해 로그인 페이지로 이동
         if (originalRequest._retry) {
           window.location.href = '/login'
-          return Promise.reject(new Error('토큰 발급에 실패했습니다.'))
+          return Promise.reject(new Error('토큰 갱신에 실패했습니다.'))
         }
 
+        // 재시도 플래그 설정
         originalRequest._retry = true
 
+        // 토큰 갱신 중인지 체크
+        if (!isRefreshing) {
+          isRefreshing = true
+
+          // 토큰 재발급 요청 Promise 생성 및 저장
+          refreshPromise = client
+            .get('/auth/re-generate-token')
+            .then(res => {
+              // 갱신 성공 시 새 토큰 저장 및 반환
+              if (res.data.statusCode === 200) {
+                const newAccessToken = res.data.data.accessToken
+                sessionStorage.setItem('accessToken', newAccessToken)
+                return newAccessToken
+              } else {
+                throw new Error('토큰 갱신에 실패했습니다.')
+              }
+            })
+            .finally(() => {
+              // 갱신 완료 후 플래그 초기화
+              isRefreshing = false
+            })
+        }
+
         try {
-          const refreshRes = await client.get('/auth/re-generate-token')
+          // 토큰 갱신 Promise 대기
+          const newAccessToken = await refreshPromise
 
-          if (refreshRes.data.statusCode === 200) {
-            const newAccessToken = refreshRes.data.data.accessToken
-            sessionStorage.setItem('accessToken', newAccessToken)
-
-            // 원래 요청에 새로운 토큰 헤더 설정
-            originalRequest.headers = {
-              ...originalRequest.headers,
-              Authorization: `Bearer ${newAccessToken}`,
-            }
-
-            // 원래 요청 재시도
-            return client(response.config)
+          // 원래 요청에 새로운 토큰 헤더 설정
+          originalRequest.headers = {
+            ...originalRequest.headers,
+            Authorization: `Bearer ${newAccessToken}`,
           }
-        } catch (refreshError) {
-          console.log(refreshError)
+
+          // 원래 요청 재시도
+          return client(originalRequest)
+        } catch (error) {
+          // 토큰 갱신 실패 시 로그인 페이지로 이동 유도
           window.location.href = '/login'
-          return Promise.reject(refreshError)
+          return Promise.reject(error)
         }
       }
 
+      // 토큰 만료 아닐 경우 정상 응답 반환
       return response
     },
     error => {


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 같은 요청 무한 루프 방지 플래그를 사용
2. 토큰 재발급 race condition 방지 로직 구현r
## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 무한 재시도 방지를 위해 요청에 `_retry` 플래그 추가 및 실패 시 로그인 페이지로 이동 처리
- 여러 API 요청이 동시에 토큰 만료 상태일 때, 중복된 토큰 갱신 요청을 하나로 묶도록 개선
- refreshToken 갱신 중에는 기존 갱신 요청 Promise를 재사용하여 불필요한 재요청 방지
- 토큰 갱신 후 모든 대기 중인 요청에 새로운 accessToken을 적용하여 재요청 처리

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 토큰 만료 시, 페이지 에러 뜨는 문제 없을겁니다!!!

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
